### PR TITLE
Add #Pragma Mark community, organizers of #PragmaConference

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Feel free to add other follow worthy Twitter accounts.
 * [@nsspain](https://twitter.com/nsspain) - The only conference for iOS and Mac in Spain.
 * [@swiftsummit](https://twitter.com/swiftsummit) - The premier Swift conference for developers.
 * [@uikonf](https://twitter.com/uikonf) - Berlin's independent conference for serious iOS developers.
+* [@pragmamarkorg](https://twitter.com/pragmamarkorg) - Italian Apple Dev Community. We organize the #PragmaConference.
 
 # Blogs
 * [@iosdevweekly](https://twitter.com/iosdevweekly) - a hand-picked round up of the best iOS development links every week.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Feel free to add other follow worthy Twitter accounts.
 * [@rjonesy](https://twitter.com/rjonesy) - founder for Weather Line.
 * [@steipete](https://twitter.com/steipete) - creator of PSPDFKit.
 * [@stroughtonsmith](https://twitter.com/stroughtonsmith) - iOS developer, discovering details about future releases.
+* [@johnsundell](https://twitter.com/johnsundell) - creator of Marathon, SwiftPlate, Unbox/Wrap & more. Blogger & podcaster.
 
 # Conferences
 * [@nsspain](https://twitter.com/nsspain) - The only conference for iOS and Mac in Spain.


### PR DESCRIPTION
Right now the #Pragma Mark community didn't create a specific account for the #Pragma Conference, they use the account of the community as reference: http://pragmaconference.com