### PR TITLE
Added Twitter List

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Feel free to add other follow worthy Twitter accounts.
 * [People](#people)
 * [Conferences](#conferences)
 * [Blogs](#blogs)
-* [Twitter List](#twitterlist)
+* [Twitter List](#twitter list)
 * [Contributing](#contributing-and-license)
 
 # People

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Feel free to add other follow worthy Twitter accounts.
 * [Conferences](#conferences)
 * [Blogs](#blogs)
 * [Contributing](#contributing-and-license)
+* [Extras](#extras)
 
 # People
 * [@_ryannystrom](https://twitter.com/_ryannystrom) - writer at rwenderlich and core contributor to [IGListKit](https://github.com/Instagram/IGListKit/).
@@ -55,3 +56,7 @@ Feel free to add other follow worthy Twitter accounts.
 
 * [CONTRIBUTING.md](https://github.com/carolanitz/Awesome-iOS-Twitter/blob/master/CONTRIBUTING.md)
 * To the extent possible under law, Carola Nitz has waived all copyright and related or neighboring rights to this work. See LICENSE for more information.
+
+# Extras
+
+* [Twitter List](https://twitter.com/russjr08/lists/awesome-ios-development) - An easily subscribable Twitter List containing the accounts listed above.

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Feel free to add other follow worthy Twitter accounts.
 * [People](#people)
 * [Conferences](#conferences)
 * [Blogs](#blogs)
+* [Twitter List](#twitterlist)
 * [Contributing](#contributing-and-license)
-* [Extras](#extras)
 
 # People
 * [@_ryannystrom](https://twitter.com/_ryannystrom) - writer at rwenderlich and core contributor to [IGListKit](https://github.com/Instagram/IGListKit/).
@@ -52,11 +52,11 @@ Feel free to add other follow worthy Twitter accounts.
 * [@objcio](https://twitter.com/objcio) - publishes books, videos, and articles on advanced techniques for iOS and OS X development.
 * [@swiftlybrief](https://twitter.com/swiftlybrief) - a community driven newsletter about about Swift.org
 
+# Twitter List
+
+* [Twitter List](https://twitter.com/russjr08/lists/awesome-ios-development) - An easily subscribable Twitter List containing the accounts listed above.
+
 # Contributing and License
 
 * [CONTRIBUTING.md](https://github.com/carolanitz/Awesome-iOS-Twitter/blob/master/CONTRIBUTING.md)
 * To the extent possible under law, Carola Nitz has waived all copyright and related or neighboring rights to this work. See LICENSE for more information.
-
-# Extras
-
-* [Twitter List](https://twitter.com/russjr08/lists/awesome-ios-development) - An easily subscribable Twitter List containing the accounts listed above.


### PR DESCRIPTION
I've never used Twitter lists before (now is a great time to start though!) so I'm not sure how many people use them, but I thought I would put together a list that contains the accounts listed here, so that way you can easily subscribe, and also be able to view _just_ iOS development related stuff in a RSS-esque format on the web / in most Twitter clients, like this (see the right side):

![Tweetbot screenshot](https://user-images.githubusercontent.com/773179/29386898-bc1448a2-82ab-11e7-92cf-df62f0b681c0.png)

I'll "watch" the repo to get PR alerts and add new accounts, since I don't believe there's a way to make the list editable, but in the future it'd be cool to have a script that watches the comments of PRs for something like `!add @handlehere` and then have it add the account to the list that way. Not sure how plausible that is as I've never worked with the GitHub API, but it seems like a nice small project I or anyone could implement. 👍 
